### PR TITLE
Fix degenerate cases in skew and kurtosis to match scipy

### DIFF
--- a/crick/stats_stubs.c
+++ b/crick/stats_stubs.c
@@ -30,7 +30,6 @@ CRICK_INLINE stats_t *stats_new() {
     T->m2 = 0;
     T->m3 = 0;
     T->m4 = 0;
-
     return T;
 }
 
@@ -100,7 +99,7 @@ CRICK_INLINE double stats_std(stats_t *T, long ddof) {
 
 CRICK_INLINE double stats_skew(stats_t *T, int bias) {
     double n, m2, m3, skew;
-    if (!T->count) return NPY_NAN;
+    if (T->count < 2) return NPY_NAN;
     n = T->count;
     m2 = T->m2 / T->count;
     m3 = T->m3 / T->count;
@@ -113,7 +112,7 @@ CRICK_INLINE double stats_skew(stats_t *T, int bias) {
 
 CRICK_INLINE double stats_kurt(stats_t *T, int fisher, int bias) {
     double n, m2, m4, kurt;
-    if (!T->count) return NPY_NAN;
+    if (T->count < 2) return NPY_NAN;
     n = T->count;
     m2 = T->m2 / T->count;
     m4 = T->m4 / T->count;

--- a/crick/stats_stubs.c
+++ b/crick/stats_stubs.c
@@ -99,6 +99,7 @@ CRICK_INLINE double stats_std(stats_t *T, long ddof) {
 
 CRICK_INLINE double stats_skew(stats_t *T, int bias) {
     double n, m2, m3, skew;
+    // XXX: this should check that T->nunique > 1
     if (T->count < 2) return NPY_NAN;
     n = T->count;
     m2 = T->m2 / T->count;
@@ -112,6 +113,7 @@ CRICK_INLINE double stats_skew(stats_t *T, int bias) {
 
 CRICK_INLINE double stats_kurt(stats_t *T, int fisher, int bias) {
     double n, m2, m4, kurt;
+    // XXX: this should check that T->nunique > 1
     if (T->count < 2) return NPY_NAN;
     n = T->count;
     m2 = T->m2 / T->count;

--- a/crick/tests/test_stats.py
+++ b/crick/tests/test_stats.py
@@ -1,4 +1,3 @@
-
 import pickle
 from copy import copy
 
@@ -49,7 +48,7 @@ def test_basic_stats(x):
     [
         normal,
         empty,
-        pytest.param(one, marks=scipy_xfail_mark),
+        one,
         pytest.param(duplicate, marks=scipy_xfail_mark),
         different,
     ],
@@ -69,7 +68,7 @@ def test_skew(x, bias):
     [
         normal,
         empty,
-        pytest.param(one, marks=scipy_xfail_mark),
+        one,
         pytest.param(duplicate, marks=scipy_xfail_mark),
         different,
     ],


### PR DESCRIPTION
Edit -- rescoped this PR to only include cases where len(array) == 1

Scipy now returns NaN when then length of the array is 1 or there is only one distinct value. This PR aims to fix that and close #31

- [x] `len(x) = 1` case 

