### PR TITLE
Exclude sources and tests from wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,12 @@ dynamic = ["version"]
 Source = "https://github.com/dask/crick"
 
 [tool.setuptools]
-include-package-data = true
+include-package-data = false
 zip-safe = false
 
 [tool.setuptools.packages.find]
 namespaces = false
+exclude = ["crick.tests*"]
 
 [tool.versioneer]
 VCS = "git"


### PR DESCRIPTION
Those shouldn't be required for the wheel, making it smaller.
