### PR TITLE
Rebuild with ``numpy`` 2+

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -19,7 +19,7 @@ jobs:
 
     env:
       CIBW_SKIP: "pp*"
-      CIBW_BEFORE_BUILD: pip install "numpy>=1.26.2" --config-settings=setup-args="-Dallow-noblas=true"
+      CIBW_BEFORE_BUILD: pip install "numpy>=2.0.0" --config-settings=setup-args="-Dallow-noblas=true"
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=68.2.2",
     "setuptools-scm[toml]>=6.2",
     "Cython",
-    "numpy>=1.26.2",
+    "numpy>=2.0.0",
     "versioneer[toml]",
 ]
 build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
@phofl mentioned offline that something like this should fix allow `crick` to be installed alongside `numpy=2`

xref https://github.com/dask/crick/issues/53