### PR TITLE
Add a runtime dependency on numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ license = {text = "BSD-3-Clause"}
 readme = "README.rst"
 requires-python = ">=3.10"
 dynamic = ["version"]
+dependencies = [
+    "numpy>=2.0.0",
+]
 
 [project.urls]
 Source = "https://github.com/dask/crick"


### PR DESCRIPTION
This needs to be a runtime dependency, not only a build-time dependency.

Fixes:

```
$ python3 -m venv _e
$ . _e/bin/activate
(_e) $ pip install crick
(_e) $ python -c 'import crick'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import crick
  File "/home/ben/tmp/_e/lib64/python3.13/site-packages/crick/__init__.py", line 3, in <module>
    from .space_saving import SpaceSaving
  File "crick/space_saving.pyx", line 1, in init crick.space_saving
ModuleNotFoundError: No module named 'numpy'
```