### PR TITLE
Avoid dereferencing a type-punned pointer

### DIFF
--- a/crick/space_saving_stubs.c.in
+++ b/crick/space_saving_stubs.c.in
@@ -460,5 +460,7 @@ finish:
  * as int64. Define a small helper to view float64 as int64: */
 
 CRICK_INLINE npy_int64 asint64(npy_float64 key) {
-  return *(npy_int64 *)(&key);
+  npy_int64 bytes;
+  memcpy(&bytes, &key, sizeof(bytes));
+  return bytes;
 }


### PR DESCRIPTION
Fixes this GCC warning without the need of adding `-fno-strict-aliasing` to the build flags:
```
  In file included from crick/space_saving.c:1263:
  crick/space_saving_stubs.c: In function ‘asint64’:
  crick/space_saving_stubs.c:808:11: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
    808 |   return *(npy_int64 *)(&key);
        |           ^~~~~~~~~~~~~~~~~~~
```
