### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,9 +22,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-variant: Mambaforge
           miniforge-version: latest
           use-mamba: true
           channel-priority: strict

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.22.0
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: wheels
           path: ./wheelhouse
@@ -45,7 +45,7 @@ jobs:
       - name: Build sdist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: dist/*.tar.gz
 

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -31,8 +31,8 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels
-          path: ./wheelhouse
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl
 
   build_sdist:
     name: Build source distribution
@@ -61,8 +61,9 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          name: wheels
+          pattern: cibw-wheels-*
           path: dist
+          merge-multiple: true
 
       - name: test
         run: |
@@ -81,8 +82,9 @@ jobs:
 
       - uses: actions/download-artifact@v3
         with:
-          name: wheels
+          pattern: cibw-wheels-*
           path: dist
+          merge-multiple: true
 
       - uses: pypa/gh-action-pypi-publish@v1.5.0
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -54,12 +54,12 @@ jobs:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           pattern: cibw-wheels-*
           path: dist
@@ -75,12 +75,12 @@ jobs:
     if: "startsWith(github.ref, 'refs/tags/')"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           pattern: cibw-wheels-*
           path: dist


### PR DESCRIPTION
- The mambaforge variant in `conda-incubator/setup-miniconda` is no longer available (gives 404 errors). The recommendation is to use vanilla miniconda now. 
- `actions/upload-artifact@v3` and `actions/download-artifact@v3` are no longer available, so bumping to v4